### PR TITLE
Set options using new 'Marked' function signature 

### DIFF
--- a/tasks/markdown.js
+++ b/tasks/markdown.js
@@ -57,11 +57,9 @@ module.exports = function(grunt) {
 
     }
 
-    markdown.setOptions(options);
-
     grunt.verbose.write('Marking down...');
 
-    html = markdown(src);
+    html = markdown(src, options);
 
     return _.template(template, {content:html});
 


### PR DESCRIPTION
I assume that newer versions of the marked library handle
the options differently because it wasn't working in code
blocks for me. Now, however, code blocks are being highlighted
correctly after this fix.
