### PR TITLE
Added some changes to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,47 @@
-# TL;DR
-[Video and Blog Post using
-grunt-markdown](http://treasonx.com/articles/GruntMarkDown.html)
-
 # grunt-markdown
 
-Compile markdown to html. This grunt task will take a given set of input markdown files and convert them to HTML.It supports [GFM](http://github.github.com/github-flavored-markdown/) with code highlighting. The code highlighting is done using [highlight.js](http://softwaremaniacs.org/soft/highlight/en/).
+This grunt task takes a set of markdown files and converts them to HTML. It supports [GFM](http://github.github.com/github-flavored-markdown/) with code highlighting. The code highlighting is done using [highlight.js](http://softwaremaniacs.org/soft/highlight/en/).
 
 ## Getting Started
-Install this grunt plugin next to your project's [Gruntfile.js][getting_started] with: `npm install grunt-markdown`
+Install this grunt plugin next to your project's [grunt.js gruntfile](http://gruntjs.com/getting-started) with:
 
-Then add this line to your project's `grunt.js` gruntfile:
+```shell
+npm install grunt-markdown
+```
+
+Then add this line to your gruntfile:
 
 ```javascript
 grunt.loadNpmTasks('grunt-markdown');
 ```
 
-[grunt]: http://gruntjs.com/
-[getting_started]: https://github.com/gruntjs/grunt/blob/master/docs/getting_started.md
-
 ## Documentation
-Creating a markdown task is simple. In your grunt file add the following config.
+Creating a markdown task is simple. For the basic functionality add the following config in your gruntfile:
 
 ```javascript
 grunt.initConfig({
   markdown: {
     all: {
-      files: ['test/sample/*'],
-      dest: 'test/out',
+      files: ['docs/src/*.md'],
+      dest: 'docs/html/'
+    }  
+  }  
+});
+
+```
+
+Here is an example config using all of the options:
+
+```javascript
+grunt.initConfig({
+  markdown: {
+    all: {
+      files: ['docs/src/*.md'],
+      dest: 'docs/html/',
+      template 'myTemplate.jst',
       options: {
         gfm: true,
-        highlight: manual
+        highlight: 'manual',
         codeLines: {
           before: '<span>',
           after: '</span>'
@@ -39,13 +51,12 @@ grunt.initConfig({
   }  
 });
 
-````
+```
+These are the properties that the `markdown` task accepts:
 
-The `markdown` task is a multitask and can have different targets. In the example above we have target specified called `all`.
-
-* `files`: The list of markdown files.
-* `template`: If you wish to provide your own html template specify here.
-* `dest`: The location for the compiled HTML files
+* `files`: The list of markdown files
+* `dest`: The output location for the compiled HTML files
+* `template`: If you wish to provide your own template written in `.jst`, list its location here.  Where you want the compiled markdown inserted in your template, include the following line: `<%=content%>`
 * `options`: options to be passed to the markdown parser
 
 The parser options are passed to the [marked](https://github.com/chjj/marked) markdown parser. The only option that is processed prior to compiling the markdown is the `highlight` option. If you specify `auto`or `manual` the task will handle highlighting code blocks for you use highlight.js. If you pass a custom function as the highlight option it will be used to highlight the code.
@@ -53,11 +64,6 @@ The parser options are passed to the [marked](https://github.com/chjj/marked) ma
 * `auto`: Will try to detect the language
 * `manual`: will pass the language name from markdown to the highlight function
 * `codeLines`: specify text that should wrap code lines
-
-
-###Template File
-
-You can provide any template file you would like and it will be used in place of the generic template provided. Where the HTML is injected into your template is specified using `<%=content%>` tag in your html template.
 
 ## License
 Copyright (c) 2012 James Morrin  


### PR DESCRIPTION
As a heavy grunt user, I like having the `npm install` easy to copy and paste, and adding the `--save-dev` adds it to your package.json file for your project.

The site is down for your blog post/video so I removed it.

I also made an example config for the basic setup and explained the template a bit more.
