### PR TITLE
fix(README): missing colon in json

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ grunt.initConfig({
     all: {
       files: ['docs/src/*.md'],
       dest: 'docs/html/',
-      template 'myTemplate.jst',
+      template: 'myTemplate.jst',
       options: {
         gfm: true,
         highlight: 'manual',


### PR DESCRIPTION
Missing a colon on the template field. Fix.
