### PR TITLE
Deprecation warning fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "highlight.js": "~7.3.0",
     "marked": "~0.2.5",
-    "grunt-contrib-lib": "~0.3.0",
+    "grunt-lib-contrib": "~0.3.0",
     "lodash": "~0.9.1"
   }
 }


### PR DESCRIPTION
grunt-contrib-lib has been renamed to grunt-lib-contrib

![Screen Shot 2013-04-28 at 21 08 30](https://f.cloud.github.com/assets/678372/436331/fe91f32a-b03f-11e2-9180-c89615cac99e.png)
