### PR TITLE
Add charset (UTF8) to template file

### DIFF
--- a/tasks/template.html
+++ b/tasks/template.html
@@ -1,6 +1,8 @@
 <!DOCTYPE  html>
 <html>
   <head>
+    <meta charset="utf-8">
+    
     <title>doc</title>
     <style>
       /*github.com style (c) Vasily Polovnyov <vast@whiteants.net>*/


### PR DESCRIPTION
Default template file is missing the charset information, therefore rendering special characters (like ñ á é í ó ú) as dual ascii files. This commit adds a utf8 charset declaration to the template file.
