### PR TITLE
fix highlight bug

### DIFF
--- a/tasks/lib/markdown.js
+++ b/tasks/lib/markdown.js
@@ -34,17 +34,17 @@ exports.init = function(grunt) {
       return out.join('\n');
     }
 
-    if(typeof options.highlight === 'string') {
-      if(options.highlight === 'auto') {
-        options.highlight = function(code) {
+    if(typeof options.markdownOptions.highlight === 'string') {
+      if(options.markdownOptions.highlight === 'auto') {
+        options.markdownOptions.highlight = function(code) {
           var out = hljs.highlightAuto(code).value;
           if(shouldWrap) {
             out = wrapLines(out);
           }
           return out;
         };
-      } else if (options.highlight === 'manual') {
-        options.highlight = function(code, lang) {
+      } else if (options.markdownOptions.highlight === 'manual') {
+        options.markdownOptions.highlight = function(code, lang) {
           var out = code;
           try {
             out = hljs.highlight(lang, code).value;


### PR DESCRIPTION
property hightlight is in options.markdownOptions, not in options

please check my modification

I have not learned how to use grunt to test, so the Travis CI shows my code run incorrectly.
But I try this code in my project, it runs correctly. Maybe you should modify your test.

Thanks for your code.
