### PR TITLE
Add support for more dynamic templateContexts

### DIFF
--- a/tasks/lib/markdown.js
+++ b/tasks/lib/markdown.js
@@ -16,8 +16,9 @@ var _ = require('lodash');
 exports.init = function(grunt) {
   var exports = {};
 
-  exports.markdown = function(src, options, template) {
+  exports.markdown = function(src, options, template, srcfile, destfile) {
 
+    var resp = null;
     var html = null;
     var templateContext = null;
     var codeLines = options.codeLines;
@@ -62,7 +63,7 @@ exports.init = function(grunt) {
       }
     }
 
-    markdown.setOptions(options.markdownOptions);
+    (options.parser || markdown).setOptions(options.markdownOptions);
 
     grunt.verbose.write('Marking down...');
 
@@ -72,8 +73,19 @@ exports.init = function(grunt) {
       templateContext = options.templateContext;
     }
 
+    templateContext.src = srcfile;
+    templateContext.dest = destfile;
+
     src = options.preCompile(src, templateContext) || src;
-    html = markdown(src);
+    resp = (options.parser || markdown)(src);
+
+    if ('string' === typeof(resp)) {
+        html = resp;
+    } else {
+        html = resp.html;
+        templateContext.meta = resp.meta;
+    }
+
     html = options.postCompile(html, templateContext) || html;
 
     templateContext.content = html;

--- a/tasks/markdown.js
+++ b/tasks/markdown.js
@@ -37,7 +37,9 @@ module.exports = function(grunt) {
       var content = markdown.markdown(
         grunt.file.read(src),
         options,
-        template
+        template,
+        src[0],
+        dest
       );
 
       grunt.file.write(dest, content);


### PR DESCRIPTION
Hi,

Made some changes that makes it possible to hook into parser and annotate with metadata.
- Always add source and destination file to templateContext
- Allow for parser that may find metadata
- Make parser injectable through the .parser option

The reason I needed this was to add support for dynamically generated menus.

An example parser that adds support for YAML metadata can be found here : https://github.com/tinymesh/tm-docs/commit/3004136265432a1f83ff99bf3eddc34fefc73a48.
The metadata can then be used from the template.
