### PR TITLE
Fix max stack error.

### DIFF
--- a/tasks/markdown.js
+++ b/tasks/markdown.js
@@ -42,7 +42,7 @@ module.exports = function(grunt) {
 
       grunt.file.write(dest, content);
       grunt.log.writeln('File "' + dest + '" created.');
-      next();
+      process.nextTick(next);
     }
   });
 


### PR DESCRIPTION
See http://stackoverflow.com/questions/23702801/grunt-task-error-maximum-call-stack-size-exceeded-when-using-grunt-markdown and https://github.com/caolan/async/issues/75
