### PR TITLE
Allow failures for Node 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,7 @@ before_script:
   - npm install
 notifications:
   email: false
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: "0.11"


### PR DESCRIPTION
0.11 is not stable. it is good to test it but don't fail a PR if 0.11 breaks.
