### PR TITLE
Allow template to be optional

### DIFF
--- a/tasks/lib/markdown.js
+++ b/tasks/lib/markdown.js
@@ -76,9 +76,12 @@ exports.init = function(grunt) {
     html = markdown(src);
     html = options.postCompile(html, templateContext) || html;
 
-    templateContext.content = html;
-
-    src = _.template(template, templateContext);
+    if (template) {
+      templateContext.content = html;
+      src = _.template(template, templateContext);
+    } else {
+      src = html;
+    }
     return src;
 
   };

--- a/tasks/markdown.js
+++ b/tasks/markdown.js
@@ -26,7 +26,7 @@ module.exports = function(grunt) {
       templateContext: {},
       template: path.join(__dirname, 'template.html')
     });
-    var template = grunt.file.read(options.template);
+    var template = options.template && grunt.file.read(options.template);
 
     // Iterate over all specified file groups.
     grunt.util.async.forEachLimit(this.files, 25, function (file, next) {

--- a/test/MarkdownSpec.js
+++ b/test/MarkdownSpec.js
@@ -181,5 +181,18 @@ describe('grunt-markdown', function () {
 
   });
 
+  describe('optional template', function () {
+    it('should use the template when specified', function () {
+      assert.equal($result.find('body').length, 1, 'expected the content to be wrapped by the template');
+    });
+
+    it('should ignore the template when not provided', function () {
+      template = false;
+      getjQuery();
+
+      assert.equal($result.find('body').length, 0, 'expected the content to not be wrapped');
+    });
+  });
+
 
 });


### PR DESCRIPTION
My use-case is to generate HTML partials for an Angular app.  I'm lazy, so I'd rather avoid creating a simple template like:

``` html
<%= content %>
```

Instead, I'd prefer to be able to specify the template as `false` and be done with it.  This change allows people to do just that.

``` js
markdown: {
  options: {
    template: false
  }
}
```
