### PR TITLE
Bump marked to v0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   ],
   "dependencies": {
     "highlight.js": "~7.3.0",
-    "marked": "~0.2.5",
+    "marked": "~0.3.2",
     "grunt-lib-contrib": "~0.3.0",
     "lodash": "~0.9.1"
   }


### PR DESCRIPTION
The minor bump brings two important changes into marked
1. Expose `renderer` to allow for customizing the output
2. Fixes sanitize issue for gfm codeblocks and js urls

(closes #47)
