### PR TITLE
AutoSearch for templates & bind to  templateContext directly from markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ grunt.initConfig({
         preCompile: function(src, context) {},
         postCompile: function(src, context) {},
         templateContext: {},
+        contextBinder: false,
+        contextBinderMark: '@@@',
+        autoTemplate: true,
+        autoTemplateFormat: 'jst',
         markdownOptions: {
           gfm: true,
           highlight: 'manual',
@@ -80,6 +84,10 @@ These are the properties that the `markdown` task accepts:
     * `preCompile`: is run before the markdown is compiled
     * `postCompile`: is run after the markdown has been compiled
     * `templateContext`: the default context for template expansion
+    * `contextBinder`: this option is useful when we want to bind some parameters directly from markdown files. All data is stored in `templateContext` object.
+    * `contextBinderMark`: with this option we can pass any marker between which we can grab your special parameters from markdown templates.
+    * `autoTemplate`: if this option is set to true, script will search for template automatically. Template must be placed in this same catalog where markdown files are.
+    * `autoTemplateFormat`: the template format when `autoTemplate` is `true`.
 
 ### modifying content with preCompile and postCompile
 
@@ -124,6 +132,49 @@ Most markdown options are passed as-is to the [marked](https://github.com/chjj/m
 * `auto`: Will try to detect the language
 * `manual`: will pass the language name from markdown to the highlight function
 * `codeLines`: specify text that should wrap code lines
+
+### contextBinder
+
+Below you can see example how to use this option.
+
+```javascript
+  markdown: {
+    all: {
+      files: [
+        {
+          expand: true,
+          src: 'docs/src/*.md',
+          dest: 'docs/html/',
+          ext: '.html'
+        }
+      ],
+      options: {
+        template: 'myTemplate.jst',
+        preCompile: function(src, context) {},
+        postCompile: function(src, context) {},
+        templateContext: {},
+        contextBinder: true,
+        contextBinderMark: '@@@',
+        markdownOptions: {
+          gfm: true,
+          highlight: 'manual',
+          codeLines: {
+            before: '<span>',
+            after: '</span>'
+          }
+        }
+      }
+    }
+  }
+```
+
+Then inside markdown file we have to put: `<!-- @@@key:value@@@ -->` and it will be equal to:
+
+```javascript
+templateContext: {
+  key: 'value'
+}
+```
 
 ## License
 Copyright (c) 2012-2013 James Morrin

--- a/tasks/markdown.js
+++ b/tasks/markdown.js
@@ -24,16 +24,87 @@ module.exports = function(grunt) {
       preCompile: noop,
       postCompile: noop,
       templateContext: {},
+      contextBinder: false,
+      contextBinderMark: '@@@',
+      autoTemplate: false,
+      autoTemplateFormat: "jst",
       template: path.join(__dirname, 'template.html')
     });
-    var template = grunt.file.read(options.template);
 
-    // Iterate over all specified file groups.
+    var template = null;
+
     grunt.util.async.forEachLimit(this.files, 25, function (file, next) {
-        convert(file.src, file.dest, next);
+
+      if (options.contextBinder === true) {
+        getTemplateContext(file.src);
+      }
+
+      if (options.autoTemplate === true) {
+        var workingPath = getWorkingPath(file.src),
+          templatePath = getTemplate(workingPath);
+
+        if (templatePath) {
+          options.template = path.join(templatePath);
+        }
+      }
+
+      template = grunt.file.read(options.template);
+      convert(file.src, file.dest, next);
     }.bind(this), this.async());
 
-    function convert(src, dest, next){
+    // Check if template context exists in template
+    function checkTemplateContext(file) {
+
+      return new RegExp('(' + options.contextBinderMark + ')(.*?)(' + options.contextBinderMark + ')', 'g').test(file);
+    }
+
+    // Apply new template context option to Object
+    function setTemplateContext(contextArray) {
+
+      var newTemplateContext = {};
+      contextArray.forEach(function(item) {
+        var cleanString = item.slice(options.contextBinderMark.length, -options.contextBinderMark.length),
+          separatedPairs = cleanString.split(':');
+
+        newTemplateContext[separatedPairs[0]] = separatedPairs[1];
+      });
+      options.templateContext = newTemplateContext;
+    }
+
+    // Collect context items
+    function getTemplateContext(file) {
+
+      var sourceFile = grunt.file.read(file),
+        hasTemplateContext = checkTemplateContext(sourceFile),
+        pattern = new RegExp('(' + options.contextBinderMark + ')(.*?)(' + options.contextBinderMark + ')', 'g'),
+        contextArray;
+
+      if (!hasTemplateContext) { 
+        return;
+      }
+      contextArray = sourceFile.match(pattern);
+      setTemplateContext(contextArray);
+    }
+    // Get working path to automaticaly searching for default template.
+    function getWorkingPath(file) {
+
+      var completePath = JSON.stringify(file).slice(2,-2).split('/'),
+        lastPathElement = completePath.pop(),
+        fileDirectory = completePath.splice(lastPathElement).join('/');
+
+        return fileDirectory;
+    }
+
+    // Automaticaly find temnplate in working directory.
+    function getTemplate(workingPath) {
+      
+      var templateFile = grunt.file.expand({}, workingPath + '/*.' + options.autoTemplateFormat);
+
+      return templateFile[0];
+    }
+
+    function convert(src, dest, next) {
+
       var content = markdown.markdown(
         grunt.file.read(src),
         options,

--- a/test/data/autotemplatetest.jst
+++ b/test/data/autotemplatetest.jst
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Auto Template Test</title>
+</head>
+<body>
+	test template for `autoTemplate` option.
+</body>
+</html>

--- a/test/data/bindertest.md
+++ b/test/data/bindertest.md
@@ -1,0 +1,2 @@
+<!-- @@@key:value@@@ -->
+#### test heading


### PR DESCRIPTION
Hello. I made some new functionalities for your plugin.
- we can automatically search for default template
- we can bind some arguments to the templateContext object directly from markdown files
- we can choose a template format for auto searching
- we can set own markers which are required to pass data into a markdown template

These modifications for us (@NexwayGroup) are very useful so this is a reason why I did it.
If you like it, please, accept this PR.
