### PR TITLE
Update marked requirement from ~0.3.2 to ~0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   ],
   "dependencies": {
     "highlight.js": "~8.4.0",
-    "marked": "~0.3.2",
+    "marked": "~0.5.0",
     "lodash": "~2.4.1"
   }
 }


### PR DESCRIPTION
Hey there! `grunt-markdown` is great, thanks for making it. This is a PR to upgrade the `marked` library. I'm working on using `grunt-markdown` to generate static sites and I'm having trouble mixing HTML and MD in one file without [this update](https://github.com/markedjs/marked/pull/1135).

---

Updates the requirements on [marked](https://github.com/markedjs/marked) to permit the latest version.
- [Release notes](https://github.com/markedjs/marked/releases)
- [Commits](https://github.com/markedjs/marked/commits/v0.5.0)

Signed-off-by: dependabot[bot] <support@dependabot.com>